### PR TITLE
Add method to add string without " for tags

### DIFF
--- a/src/influxdb-cpp-rest/influxdb_line.h
+++ b/src/influxdb-cpp-rest/influxdb_line.h
@@ -87,6 +87,16 @@ namespace influxdb {
                 return *this;
             }
 
+            key_value_pairs& add_no_quotes(std::string const& key, std::string const& value) {
+                ::influxdb::utility::throw_on_invalid_identifier(key);
+
+                add_comma_if_necessary();
+
+                res << key << "=" << value << "";
+
+                return *this;
+            }
+
             inline std::string get() const {
                 return res.str();
             }


### PR DESCRIPTION
* InfluxDb tag does not require quotes around string.
* New method called add_no_quotes is a special method to add string to
  key_value_paris without quotes around it.