### PR TITLE
Support inserting data with retention policy

### DIFF
--- a/src/influxdb-cpp-rest/influxdb_raw_db.h
+++ b/src/influxdb-cpp-rest/influxdb_raw_db.h
@@ -20,6 +20,7 @@ namespace influxdb {
 
             std::string username;
             std::string password;
+            std::string retention_policy;
 
         public:
             db(string_t const& url, string_t const& name);
@@ -38,6 +39,9 @@ namespace influxdb {
 
             /// set username & password for basic authentication
             void with_authentication(std::string const& username, std::string const& password);
+
+            /// set retention policy
+            void with_retention_policy(std::string const& retention_policy);
         };
     }
 }

--- a/src/influxdb-cpp-rest/influxdb_raw_db_utf8.cpp
+++ b/src/influxdb-cpp-rest/influxdb_raw_db_utf8.cpp
@@ -69,3 +69,8 @@ void influxdb::raw::db_utf8::with_authentication(std::string const& username, st
 {
     pimpl->db_utf16.with_authentication(username, password);
 }
+
+void influxdb::raw::db_utf8::with_retention_policy(std::string const& retention_policy)
+{
+    pimpl->db_utf16.with_retention_policy(retention_policy);
+}

--- a/src/influxdb-cpp-rest/influxdb_raw_db_utf8.h
+++ b/src/influxdb-cpp-rest/influxdb_raw_db_utf8.h
@@ -32,6 +32,9 @@ namespace influxdb {
 
             /// set username & password for basic authentication
             void with_authentication(std::string const& username, std::string const& password);
+
+            /// set retention policy
+            void with_retention_policy(std::string const& retention_policy);
         };
     }
 }

--- a/src/influxdb-cpp-rest/influxdb_simple_api.cpp
+++ b/src/influxdb-cpp-rest/influxdb_simple_api.cpp
@@ -53,3 +53,8 @@ void influxdb::api::simple_db::with_authentication(std::string const& username, 
 {
     pimpl->db.with_authentication(username, password);
 }
+
+void influxdb::api::simple_db::with_retention_policy(std::string const& retention_policy)
+{
+    pimpl->db.with_retention_policy(retention_policy);
+}

--- a/src/influxdb-cpp-rest/influxdb_simple_api.h
+++ b/src/influxdb-cpp-rest/influxdb_simple_api.h
@@ -27,6 +27,7 @@ namespace influxdb {
             void drop();
             void insert(line const& lines);
             void with_authentication(std::string const& username, std::string const& password);
+            void with_retention_policy(std::string const& retention_policy);
         };
     }
 

--- a/src/influxdb-cpp-rest/influxdb_simple_async_api.cpp
+++ b/src/influxdb-cpp-rest/influxdb_simple_async_api.cpp
@@ -132,3 +132,8 @@ void influxdb::async_api::simple_db::with_authentication(std::string const& user
 {
     pimpl->db.with_authentication(username, password);
 }
+
+void influxdb::async_api::simple_db::with_retention_policy(std::string const& retention_policy)
+{
+    pimpl->db.with_retention_policy(retention_policy);
+}

--- a/src/influxdb-cpp-rest/influxdb_simple_async_api.h
+++ b/src/influxdb-cpp-rest/influxdb_simple_async_api.h
@@ -29,6 +29,7 @@ namespace influxdb {
             void drop();
             void insert(influxdb::api::line const& lines);
             void with_authentication(std::string const& username, std::string const& password);
+            void with_retention_policy(std::string const& retention_policy);
         };
     }
 


### PR DESCRIPTION
Adds `influxdb::async_api::simple_db.with_retention_policy` method to support inserting data with retention policy.